### PR TITLE
Always stamp iat on encoded tokens

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"time"
 
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwt"
@@ -87,6 +88,11 @@ func main() {
 	if *fEncode {
 		// Encode new JWT token.
 		token := jwt.New()
+
+		// Stamp iat on every token; an explicit iat in -claims overrides it.
+		if err := token.Set(jwt.IssuedAtKey, time.Now()); err != nil {
+			log.Fatal(err)
+		}
 
 		var claims map[string]interface{}
 		if *fClaims != "" {


### PR DESCRIPTION
`-encode` now sets the `iat` claim to the current time on every minted token, matching what real-world issuers do. An explicit `iat` passed via `-claims` still overrides the default.

```
$ jwtutil -secret=besafe -encode

Claims: map[string]interface{}{
    "iat": time.Date(2026, time.July, 27, 20, 0, 10, 0, time.UTC),
}
```

Pairs with #6, which prints iat/exp as human-readable relative times on decode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)